### PR TITLE
Allow site to use OS username lookups instead of LDAP

### DIFF
--- a/config.ini.dist
+++ b/config.ini.dist
@@ -1,5 +1,6 @@
 [api]
 local_port = 8080
+usernames = ldap
 [slurmdb]
 host = slurmdb
 port = 3306


### PR DESCRIPTION
It can be useful to avoid LDAP lookups, either in testing or when the operating system running this program already knows who all the users are. Added new key which, if not present, means we should fall back to asking the OS:

[api]
usernames = ldap